### PR TITLE
Emit file option

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -80,6 +80,35 @@ const {%= varname %} = require('{%= name %}')
 ## API
 {%= apidocs('index.js') %}
 
+
+### File emission
+
+By default, processed code will be emitted as an ES module. In a such way, it will be wrapped with `export default` and provide a string when being imported. Usually it is expected behavior.
+However, you may have a need to get an unwrapped result, for example, to pass it to another Rollup plugin. In this case you can simply disable `emitFile` option.
+Let's have a look at the chaining PostHTML with a template compiler plugin:
+
+```js
+import dot from 'rollup-plugin-dot'
+import htmlnano from 'htmlnano'
+
+export default {
+  entry: 'foo/bar/main.js',
+  plugins: [
+    posthtml({
+      emitFile: false,
+      plugins: [
+         htmlnano()
+      ]
+    }),
+    dot({
+       templateSettings: {
+         strip: false
+       }
+    })
+  ]
+}
+```
+
 {% if (verb.related && verb.related.list && verb.related.list.length) { %}
 ## Related
 {%= related(verb.related.list, {words: 20}) %}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ with :heart: at [Sofia, Bulgaria][bulgaria-url] 🇧🇬.
 - [Usage](#usage)
 - [API](#api)
   * [rollupPluginPosthtml](#rolluppluginposthtml)
+  * [File emission](#file-emission)
 - [Related](#related)
 - [Contributing](#contributing)
 - [Building docs](#building-docs)
@@ -112,6 +113,34 @@ export default {
     posthtml({
       parser: sugarml(),
       plugins: customElements()
+    })
+  ]
+}
+```
+
+### File emission
+
+By default, processed code will be emitted as an ES module. In a such way, it will be wrapped with `export default` and provide a string when being imported. Usually it is expected behavior.
+However, you may have a need to get an unwrapped result, for example, to pass it to another Rollup plugin. In this case you can simply disable `emitFile` option.
+Let's have a look at the chaining PostHTML with a template compiler plugin:
+
+```js
+import dot from 'rollup-plugin-dot'
+import htmlnano from 'htmlnano'
+
+export default {
+  entry: 'foo/bar/main.js',
+  plugins: [
+    posthtml({
+      emitFile: false,
+      plugins: [
+         htmlnano()
+      ]
+    }),
+    dot({
+       templateSettings: {
+         strip: false
+       }
     })
   ]
 }

--- a/fixtures/foo.html
+++ b/fixtures/foo.html
@@ -2,3 +2,6 @@
   <title>Super Title</title>
   <text>Awesome Text</text>
 </component>
+<div>
+  <!--  simple comment-->
+</div>

--- a/index.js
+++ b/index.js
@@ -44,11 +44,14 @@ const utils = require('rollup-pluginutils')
 
 module.exports = function rollupPluginPosthtml (options) {
   options = Object.assign({
+    emitFile: true,
     include: '**/*.html'
   }, options)
 
   const filter = utils.createFilter(options.include, options.exclude)
-  const handle = (res) => `export default ${JSON.stringify(res.html.trim())}`
+  const handle = options.emitFile
+    ? (res) => `export default ${JSON.stringify(res.html.trim())}`
+    : (res) => res.html
 
   return {
     name: 'posthtml',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "npm-run-all": "^4.0.1",
     "nyc": "^11.0.0",
     "posthtml-custom-elements": "^1.0.3",
+    "posthtml-minifier": "^0.1.0",
     "pre-commit": "^1.2.2",
     "rollup": "^0.42.0",
     "standard": "^10.0.1",

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ const posthtml = require('./index')
 
 const rollup = require('rollup')
 const elements = require('posthtml-custom-elements')
+const minifier = require('posthtml-minifier')
 
 test('should main export return an object with transform() fn', (done) => {
   const plugin = posthtml()
@@ -45,6 +46,45 @@ test('should work as real plugin to rollup', (done) => {
 
   return promise.then((bundle) => {
     const result = bundle.generate({ format: 'iife' })
+
+    test.strictEqual(/var foo = "<div/.test(result.code), true)
+    test.strictEqual(/class=\\"component\\"/.test(result.code), true)
+    test.strictEqual(/class=\\"text\\"/.test(result.code), true)
+    test.strictEqual(/console\.log\(foo\)/.test(result.code), true)
+    done()
+  }, done).catch(done)
+})
+
+test('should emit string', (done) => {
+  const promise = rollup.rollup({
+    entry: 'fixtures/main.js',
+    plugins: [
+      posthtml({
+        plugins: [
+          elements(),
+          minifier({
+            removeComments: true
+          })
+        ],
+        emitFile: false
+      }),
+      (function rollupPluginDumb () {
+        return {
+          name: 'dumb',
+          transform: (code, id) => {
+            return id.endsWith('.html')
+              ? `export default ${JSON.stringify(code)}`
+              : null
+          }
+        }
+      })()
+    ]
+  })
+
+  return promise.then((bundle) => {
+    const result = bundle.generate({format: 'iife', moduleName: 'dumb'})
+
+    test.strictEqual(result.code.includes('<!--'), false)
 
     test.strictEqual(/var foo = "<div/.test(result.code), true)
     test.strictEqual(/class=\\"component\\"/.test(result.code), true)


### PR DESCRIPTION
Currently there is no way to chain result of PostHTML generation to other Rollup modules as a raw string. The only possible format is a wrapped anonymous module. Such way of resource emitting can't satisfy template precompiling plugins (like https://github.com/nilennoct/rollup-plugin-dot). I propose to introduce an optional unwrapped export