### PR TITLE
Pass resource id

### DIFF
--- a/fixtures/samplePlugin.js
+++ b/fixtures/samplePlugin.js
@@ -1,0 +1,5 @@
+module.exports = (data) => {
+  return function cssModules(tree) {
+    data.resourceId = tree.options.rollupResourceId;
+  };
+};

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function rollupPluginPosthtml (options) {
     name: 'posthtml',
     transform: (code, id) => (
       filter(id)
-        ? posthtml(options.plugins).process(code, options).then(handle)
+        ? posthtml(options.plugins).process(code, {...options, rollupResourceId: id}).then(handle)
         : null
     )
   }

--- a/test.js
+++ b/test.js
@@ -9,11 +9,13 @@
 
 'use strict'
 
+const path = require('path')
 const test = require('mukla')
 const posthtml = require('./index')
 
 const rollup = require('rollup')
 const elements = require('posthtml-custom-elements')
+const samplePlugin = require('./fixtures/samplePlugin')
 
 test('should main export return an object with transform() fn', (done) => {
   const plugin = posthtml()
@@ -50,6 +52,27 @@ test('should work as real plugin to rollup', (done) => {
     test.strictEqual(/class=\\"component\\"/.test(result.code), true)
     test.strictEqual(/class=\\"text\\"/.test(result.code), true)
     test.strictEqual(/console\.log\(foo\)/.test(result.code), true)
+    done()
+  }, done).catch(done)
+})
+
+test('should pass resource id', (done) => {
+  const data = {
+    resourceId: null
+  }
+  const promise = rollup.rollup({
+    entry: 'fixtures/main.js',
+    plugins: [
+      posthtml({
+        plugins: [samplePlugin(data)]
+      })
+    ]
+  })
+
+  return promise.then((bundle) => {
+    const resolvedPath = path.resolve('./fixtures/foo.html')
+    test.strictEqual(data.resourceId, resolvedPath, 'passed rollup resource id should be equal with resolved')
+
     done()
   }, done).catch(done)
 })


### PR DESCRIPTION
In process of writing my own PostHTML plugin for html.d.ts schemes generation I faced with lack of information about processing file, particularly I missed filesystem location info. As I understand, all the files are processed sequentially, so I propose to proxy current file info through PostHTML plugin options.